### PR TITLE
Setting the proper ClimateEntityFeature.

### DIFF
--- a/custom_components/duepi_evo/climate.py
+++ b/custom_components/duepi_evo/climate.py
@@ -47,7 +47,7 @@ except ImportError:
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
+SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
 
 """
 Supported hvac modes:
@@ -134,6 +134,10 @@ class DuepiEvoDevice(ClimateEntity):
     """Representation of a DuepiEvoDevice."""
 
     def __init__(self, session, config) -> None:
+
+        self._enable_turn_on_off_backwards_compatibility = False
+        self._attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
+
         """Initialize the DuepiEvoDevice."""
         self._session = session
         self._name = config.get(CONF_NAME)


### PR DESCRIPTION
WARNING (MainThread) [homeassistant.components.climate] Entity None (<class 'custom_components.duepi_evo.climate.DuepiEvoDevice'>) implements HVACMode(s): heat, off and therefore implicitly supports the turn_on/turn_off methods without setting the proper ClimateEntityFeature.