### PR TITLE
Fixed incorrect hex encoding for temperatures below 16°C in evo-python/SetPoint.py

### DIFF
--- a/evo-python/SetPoint.py
+++ b/evo-python/SetPoint.py
@@ -3,19 +3,27 @@ import sys
 import const
 
 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM);
-sock.connect(("192.168.103.11", 23))
-setPoint=sys.argv[1]
-setPointInt=int(setPoint)
-constInt=75
-codeInt=setPointInt+constInt
-codeHexStr=hex(codeInt)
-setPointHexStr=hex(setPointInt)
-data2=const.set_temperature.replace("yy",codeHexStr[2:4])
-data3=data2.replace("xx",setPointHexStr[2:4])
-sock.send(data3.encode())
-dataFromServer = sock.recv(10).decode();
-if const.str_ack in dataFromServer:
-  print("OK")
+sock.connect(("192.168.100.29", 23))
+setPoint = 20
+setPointInt = int(setPoint)
+
+if setPointInt > 15:
+    OFFSET = 75
 else:
- print(dataFromServer)
+    OFFSET = 97
+
+set_point_hex = f"{setPointInt:02X}"
+offset_hex    = f"{(setPointInt + OFFSET):02X}"
+
+data = const.set_temperature \
+    .replace("xx", set_point_hex) \
+    .replace("yy", offset_hex)
+sock.send(data.encode())
+
+dataFromServer = sock.recv(10).decode()
+if const.str_ack in dataFromServer:
+    print("OK")
+else:
+    print(dataFromServer)
+
 sock.close()


### PR DESCRIPTION
Corrected the offset and hex encoding logic so temperatures under 16°C are now handled properly when sending data to the ESP. This ensures consistent and accurate temperature adjustments across all ranges.