### PR TITLE
Fix bug for setpoints above 25°C by adding multi-offset logic

### DIFF
--- a/evo-python/SetPoint.py
+++ b/evo-python/SetPoint.py
@@ -7,10 +7,14 @@ sock.connect(("192.168.100.29", 23))
 setPoint = 20
 setPointInt = int(setPoint)
 
-if setPointInt > 15:
-    OFFSET = 75
-else:
+if setPointInt < 16:
     OFFSET = 97
+elif setPointInt <= 25:
+    OFFSET = 75
+elif setPointInt <= 31:
+    OFFSET = 82
+else:
+    OFFSET = 60
 
 set_point_hex = f"{setPointInt:02X}"
 offset_hex    = f"{(setPointInt + OFFSET):02X}"


### PR DESCRIPTION
Previously, offsets above 25°C weren’t applied correctly. Now offsets vary by range:
- <16°C → 97
- 16–25°C → 75
- 26–31°C → 82
- ≥32°C → 60