### PR TITLE
Fix init_command schema type to boolean

### DIFF
--- a/custom_components/duepi_evo/climate.py
+++ b/custom_components/duepi_evo/climate.py
@@ -91,7 +91,7 @@ PLATFORM_SCHEMA = CLIMATE_PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_AUTO_RESET, default=DEFAULT_AUTO_RESET): cv.boolean,
         vol.Optional(CONF_NOFEEDBACK, default=DEFAULT_NOFEEDBACK): cv.positive_float,
         vol.Optional(CONF_UNIQUE_ID, default=DEFAULT_UNIQUE_ID): cv.string,
-        vol.Optional(CONF_INIT_COMMAND, default=DEFAULT_INIT_COMMAND): cv.string,
+        vol.Optional(CONF_INIT_COMMAND, default=DEFAULT_INIT_COMMAND): cv.boolean,
     }
 )
 


### PR DESCRIPTION
## Summary
This follow up fixes the `init_command` config schema type in the Home Assistant platform schema.

`init_command` was validated as `cv.string`, but used as a boolean (`if self.init_command:`).
This could lead to unexpected behavior because non empty strings like `"false"` are truthy in Python.

## Change
`CONF_INIT_COMMAND` validation changed from `cv.string` to `cv.boolean` in `custom_components/duepi_evo/climate.py`.

## Why
This makes `init_command: true/false` behave reliably and avoids accidental init command sends.

## Validation
File compiles successfully with `python3 -m py_compile custom_components/duepi_evo/climate.py`.
