### PR TITLE
Fix read alignment after init_command + defensive fan_mode parsing

### DIFF
--- a/custom_components/duepi_evo/climate.py
+++ b/custom_components/duepi_evo/climate.py
@@ -456,6 +456,9 @@ class DuepiEvoDevice(ClimateEntity):
     async def async_update(self) -> None:
         """Update local data with data from stove."""
         data = await self.get_data(SUPPORT_SETPOINT)
+        if data is None:
+            _LOGGER.error("%s: No data received during update", self._name)
+            return
         self._burner_status = data[0]
         self._current_temperature = data[1]
         self._current_fan_mode = self._fan_mode_map_rev.get(data[2])


### PR DESCRIPTION
## Summary
This PR reintroduces init_command safely after the v2026.02.27 revert context.

It addresses the regression reported in #69 by:
1. consuming any immediate optional response frame after sending init_command
2. making fan mode parsing defensive to avoid KeyError on unexpected values

## Why
Some stove models appear to emit an extra frame after init. If not consumed, subsequent reads can be shifted, resulting in invalid fan mode integers (e.g. 513/2049) and startup crashes.

## Changes
- add init_command config option back with boolean schema
- send optional init command before commands/polling
- drain optional immediate init response frame (non-blocking readiness check)
- guard fan mode mapping with fallback (Off) + warning log

## Validation
- python3 -m py_compile custom_components/duepi_evo/climate.py

Closes #69
