### PR TITLE
Harden validate workflow token permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Adds an explicit minimal permissions block to `.github/workflows/validate.yml`:

- `contents: read`

This follows the principle of least privilege for `GITHUB_TOKEN` and addresses the open CodeQL/code-scanning warning about missing workflow permissions:
- https://github.com/aceindy/Duepi_EVO/security/code-scanning/1

No functional workflow changes are intended.
