### PR TITLE
Fix HACS manifest validation

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,4 @@
 {
   "name": "Duepi Evo",
-  "render_readme": true,
-  "iot_class": "local_polling"
+  "render_readme": true
 }


### PR DESCRIPTION
Removes the unsupported `iot_class` key from `hacs.json`.

This is intended to fix the failing `Validate` workflow on `main`:
- `hacs/action` currently rejects `iot_class` as an extra key in the HACS manifest.

No runtime integration behavior is changed.
