### PR TITLE
Follow up PR84: parametrize HVAC mapping tests

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -144,12 +144,26 @@ def test_fetch_state_parses_protocol_frames(monkeypatch: pytest.MonkeyPatch) -> 
     assert state.heating is True
 
 
-def test_hvac_from_status_maps_cooling_down_to_heat_without_heating() -> None:
-    """Cooling down should keep HEAT mode while exposing an idle action."""
-    hvac_mode, heating = DuepiEvoClient._hvac_from_status("Cooling down")
+@pytest.mark.parametrize(
+    ("status", "expected_hvac_mode", "expected_heating"),
+    [
+        ("Off", HVACMode.OFF, False),
+        ("Cooling down", HVACMode.HEAT, False),
+        ("Flame On", HVACMode.HEAT, True),
+        ("Eco idle", HVACMode.HEAT, True),
+        ("Cleaning", HVACMode.HEAT, True),
+    ],
+)
+def test_hvac_from_status_mapping(
+    status: str,
+    expected_hvac_mode: HVACMode,
+    expected_heating: bool,
+) -> None:
+    """Burner status should map to the expected HVAC mode and heating flag."""
+    hvac_mode, heating = DuepiEvoClient._hvac_from_status(status)
 
-    assert hvac_mode == HVACMode.HEAT
-    assert heating is False
+    assert hvac_mode == expected_hvac_mode
+    assert heating is expected_heating
 
 
 def test_fetch_state_raises_protocol_error_on_malformed_frame(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_climate_hvac_action.py
+++ b/tests/test_climate_hvac_action.py
@@ -14,15 +14,64 @@ from custom_components.duepi_evo.climate import DuepiEvoClimateEntity
 pytestmark = [pytest.mark.usefixtures("enable_custom_integrations")]
 
 
-def test_hvac_action_is_idle_while_cooling_down() -> None:
-    """Cooling down should report idle action while staying in heat mode."""
+def _entity_with_state(state: SimpleNamespace | None) -> DuepiEvoClimateEntity:
+    """Create a minimal climate entity bound to a specific coordinator state."""
     entity = DuepiEvoClimateEntity.__new__(DuepiEvoClimateEntity)
-    entity.coordinator = SimpleNamespace(
-        data=SimpleNamespace(
-            burner_status="Cooling down",
-            heating=False,
-            hvac_mode=HVACMode.HEAT,
-        )
-    )
+    entity.coordinator = SimpleNamespace(data=state)
+    return entity
 
-    assert entity.hvac_action == HVACAction.IDLE
+
+@pytest.mark.parametrize(
+    ("state", "expected_action"),
+    [
+        (None, HVACAction.OFF),
+        (
+            SimpleNamespace(
+                burner_status="Flame On",
+                heating=True,
+                hvac_mode=HVACMode.HEAT,
+            ),
+            HVACAction.HEATING,
+        ),
+        (
+            SimpleNamespace(
+                burner_status="Cooling down",
+                heating=False,
+                hvac_mode=HVACMode.HEAT,
+            ),
+            HVACAction.IDLE,
+        ),
+        (
+            SimpleNamespace(
+                burner_status="Eco idle",
+                heating=False,
+                hvac_mode=HVACMode.HEAT,
+            ),
+            HVACAction.IDLE,
+        ),
+        (
+            SimpleNamespace(
+                burner_status="Cleaning",
+                heating=False,
+                hvac_mode=HVACMode.HEAT,
+            ),
+            HVACAction.IDLE,
+        ),
+        (
+            SimpleNamespace(
+                burner_status="Off",
+                heating=False,
+                hvac_mode=HVACMode.OFF,
+            ),
+            HVACAction.OFF,
+        ),
+    ],
+)
+def test_hvac_action_mapping(
+    state: SimpleNamespace | None,
+    expected_action: HVACAction,
+) -> None:
+    """HVAC action should reflect the key heating, idle, and off combinations."""
+    entity = _entity_with_state(state)
+
+    assert entity.hvac_action == expected_action


### PR DESCRIPTION
## Summary
Follow-up to PR84 that applies the review feedback about parametrized HVAC mapping tests.

## Included
- replace the single `Cooling down` client test with a parametrized status matrix
- replace the single `hvac_action` entity test with a parametrized action matrix
- keep the scope test-only, with no runtime behavior changes

## Why
PR84 is already merged and the functional fix is correct. This small follow-up keeps the history clean while making the tested HVAC combinations easier to review and extend.
