### PR TITLE
Fix target temperature fallback without setpoint feedback

### DIFF
--- a/custom_components/duepi_evo/client.py
+++ b/custom_components/duepi_evo/client.py
@@ -285,7 +285,7 @@ class DuepiEvoClient:
                 setpoint_response = self._send_and_recv(sock, GET_SETPOINT)
                 setpoint_raw = self._read_hex_value(setpoint_response, 4)
                 target_temperature = None
-                if setpoint_raw != 0 and self.min_temp < setpoint_raw < self.max_temp:
+                if setpoint_raw != 0 and self.min_temp <= setpoint_raw <= self.max_temp:
                     target_temperature = float(setpoint_raw)
 
                 pcb_temp = self._optional_read(

--- a/custom_components/duepi_evo/climate.py
+++ b/custom_components/duepi_evo/climate.py
@@ -272,6 +272,7 @@ class DuepiEvoClimateEntity(CoordinatorEntity[DuepiEvoCoordinator], ClimateEntit
         self._min_temp = min_temp
         self._max_temp = max_temp
         self._no_feedback = no_feedback
+        self._last_target_temperature: float | None = None
         self._legacy_attr_warning_logged = False
 
     @property
@@ -328,6 +329,8 @@ class DuepiEvoClimateEntity(CoordinatorEntity[DuepiEvoCoordinator], ClimateEntit
         state = self._state
         if state and state.target_temp_c is not None:
             return state.target_temp_c
+        if self._last_target_temperature is not None:
+            return self._last_target_temperature
         return float(self._no_feedback)
 
     @property
@@ -427,10 +430,12 @@ class DuepiEvoClimateEntity(CoordinatorEntity[DuepiEvoCoordinator], ClimateEntit
             _LOGGER.debug("%s: Unable to use target temp", self._name)
             return
 
+        target_temperature = float(target_temperature)
+
         try:
             await self.hass.async_add_executor_job(
                 self.coordinator.client.set_temperature,
-                float(target_temperature),
+                target_temperature,
             )
         except DuepiEvoClientError as err:
             _LOGGER.error(
@@ -441,6 +446,7 @@ class DuepiEvoClimateEntity(CoordinatorEntity[DuepiEvoCoordinator], ClimateEntit
             )
             return
 
+        self._last_target_temperature = target_temperature
         await self.coordinator.async_request_refresh()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -113,7 +113,18 @@ def test_set_temperature_skips_init_command_when_disabled(monkeypatch: pytest.Mo
     assert b"RF2170" in sent_frames[0]
 
 
-def test_fetch_state_parses_protocol_frames(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    ("setpoint_response", "expected_target_temp"),
+    [
+        ("\x1b00170000&", 23.0),
+        ("\x1b00100000&", 16.0),
+    ],
+)
+def test_fetch_state_parses_protocol_frames(
+    monkeypatch: pytest.MonkeyPatch,
+    setpoint_response: str,
+    expected_target_temp: float,
+) -> None:
     """Fetch should decode burner, fan, temperatures, speed and error code."""
     responses = [
         "\x1b02000000&",  # status => Flame On
@@ -123,7 +134,7 @@ def test_fetch_state_parses_protocol_frames(monkeypatch: pytest.MonkeyPatch) -> 
         "\x1b00C80000&",  # flugas => 200 C
         "\x1b00320000&",  # exh fan raw => 50 * 10 => 500 rpm
         "\x1b00050000&",  # error => 5 => Out of pellets
-        "\x1b00170000&",  # setpoint => 23
+        setpoint_response,
         "\x1b002D0000&",  # pcb temp => 45 C
         "\x1b0001F400&",  # total burn time => 500 h
         "\x1b00002A00&",  # burn time since reset => 42 h
@@ -146,7 +157,7 @@ def test_fetch_state_parses_protocol_frames(monkeypatch: pytest.MonkeyPatch) -> 
     assert state.flu_gas_temp_c == 200
     assert state.exh_fan_speed_rpm == 500
     assert state.error_code == "Out of pellets"
-    assert state.target_temp_c == 23.0
+    assert state.target_temp_c == expected_target_temp
     assert state.pcb_temp_c == 45
     assert state.total_burn_time_h == 500
     assert state.burn_time_since_reset_h == 42

--- a/tests/test_climate_hvac_action.py
+++ b/tests/test_climate_hvac_action.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -75,3 +76,33 @@ def test_hvac_action_mapping(
     entity = _entity_with_state(state)
 
     assert entity.hvac_action == expected_action
+
+
+def test_set_temperature_keeps_commanded_value_without_setpoint_feedback() -> None:
+    """No-feedback stoves should keep a successful command instead of reverting to fallback."""
+    captured: dict[str, float] = {}
+
+    def set_temperature(target_temperature: float) -> None:
+        captured["target_temperature"] = target_temperature
+
+    async def async_add_executor_job(func, *args):
+        return func(*args)
+
+    async def refresh_without_feedback() -> None:
+        coordinator.data = SimpleNamespace(target_temp_c=None)
+
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(target_temp_c=None),
+        client=SimpleNamespace(set_temperature=set_temperature),
+        async_request_refresh=refresh_without_feedback,
+    )
+    entity = DuepiEvoClimateEntity.__new__(DuepiEvoClimateEntity)
+    entity.coordinator = coordinator
+    entity.hass = SimpleNamespace(async_add_executor_job=async_add_executor_job)
+    entity._name = "Duepi EVO"
+    entity._no_feedback = 16.0
+
+    asyncio.run(entity.async_set_temperature(temperature=24))
+
+    assert captured["target_temperature"] == 24.0
+    assert entity.target_temperature == 24.0


### PR DESCRIPTION
## Summary
- keep the last successfully requested target temperature when a stove does not report setpoint feedback
- accept configured min/max temperatures as valid reported setpoints
- add focused regression coverage for no-feedback target temperature handling and boundary setpoints

Fixes #89

## Verification
- `pytest tests/test_client.py` -> 12 passed
- `python -m compileall custom_components tests` -> OK
- `git diff --check` -> OK
- Docker/Home Assistant smoke using `ghcr.io/home-assistant/home-assistant:2026.2.2` + `evo-python/EVO-sim.py` -> Phase 2 OK, 9 sensors, 1 binary sensor

## Note
The repository `scripts/smoke_migration.sh --skip-migration` path was attempted first, but the devcontainer Dockerfile currently crashes during `pip install -r requirements_test.txt` before Home Assistant starts. The smoke was therefore run against the official Home Assistant image with the same integration and emulator.